### PR TITLE
Remove trailing ':' from heading

### DIFF
--- a/docs/dev-docs/modules/internationalization/pages/index.adoc
+++ b/docs/dev-docs/modules/internationalization/pages/index.adoc
@@ -53,7 +53,7 @@ image:/images/developer/internationalization-and-localization/download_jenkins_d
 // https://github.com/stapler/netbeans-stapler-plugin[NetBeans
 // plugin for Stapler] for details.
 
-== References:
+== References
 
 - link:https://github.com/glasswalk3r/jenkins-translation-tool#readme[Jenkins translation tool by Alceu Rodrigues de Freitas Junior]
 - link:https://wiki.jenkins.io/display/JENKINS/Translation+Tool[Original translation tool]


### PR DESCRIPTION
Mark Waite doesn't like the trailing colon

Opinion mode off...