### PR TITLE
fix: Plugin site reference via Asciidoc attributes

### DIFF
--- a/docs/dev-docs/modules/plugin-development/pages/pipeline-integration.adoc
+++ b/docs/dev-docs/modules/plugin-development/pages/pipeline-integration.adoc
@@ -205,7 +205,7 @@ and should at least have been using `Secret`.
 `Secret`-valued fields are more secure, but are not really appropriate for projects defined in source code,
 like Pipeline jobs.
 
-Instead you should integrate with the plugin:credentials[Credentials plugin].
+Instead you should integrate with the {plugin}/credentials[Credentials plugin].
 Then your builder etc. would typically have a `credentialsId` field which just refers to the ID of the credentials.
 (The user can pick a mnemonic ID for use in scripted jobs.)
 Typically the `config.jelly` used in _Snippet Generator_ will have a `<c:select/>` control,

--- a/docs/dev-docs/modules/publishing/pages/releasing-experimental-updates.adoc
+++ b/docs/dev-docs/modules/publishing/pages/releasing-experimental-updates.adoc
@@ -40,7 +40,7 @@ The experimental update center only offers the latest version of each plugin, ev
 
 === In Jenkins Configuration-as-Code plugin
 
-plugin:configuration-as-code[Jenkins Configuration-as-Code plugin] allows configuring update centers in configuration YAMLs.
+{plugin}/configuration-as-code[Jenkins Configuration-as-Code plugin] allows configuring update centers in configuration YAMLs.
 Once configured, it will be possible to install experimenta plugins and versions from the _Plugin Manager_ Web UI.
 
 ```yml

--- a/docs/dev-docs/modules/security/pages/misc.adoc
+++ b/docs/dev-docs/modules/security/pages/misc.adoc
@@ -76,7 +76,7 @@ Ignoring SSL/TLS errors is only permitted if the following constraints are both 
 1. Ignoring SSL/TLS errors is limited to the specific connections opened by the plugin.
    Plugins should never cause SSL/TLS errors to be ignored for the entire Jenkins instance.
    As a consequence, APIs like `HttpsURLConnection#setDefaultHostnameVerifier` or `HttpsURLConnection#setDefaultSSLSocketFactory` must not be called by plugins.
-   The only exceptions to this rule are dedicated plugins with only this purpose, like plugin:skip-certificate-check[skip-certificate-check].
+   The only exceptions to this rule are dedicated plugins with only this purpose, like {plugin}/skip-certificate-check[skip-certificate-check].
 2. Ignoring SSL/TLS problems for specific connections (e.g. `HttpsURLConnection#setHostnameVerifier` or `HttpsURLConnection#setSSLSocketFactory`) is allowed, but users need to opt in to this behavior.
    By default, SSL/TLS problems must not be ignored.
 
@@ -121,12 +121,12 @@ It needs to be configured to prevent the instantiation of arbitrary types.
 
 When using SnakeYAML, make sure to never use the parameterless `new Yaml()` constructor, but to pass a `SafeConstructor` as argument (or otherwise restrict what can be deserialized).
 Additionally, use at least version 1.26 to get denial-of-service protection ("billion laughs").
-Consider depending on the plugin:snakeyaml-api[SnakeYAML API Plugin] instead of bundling SnakeYAML with your plugin.
+Consider depending on the {plugin}/snakeyaml-api[SnakeYAML API Plugin] instead of bundling SnakeYAML with your plugin.
 
 
 === Groovy Scripting
 
 Many Jenkins plugins allow the use of Groovy to extend their capabilities.
-For example, the plugin:email-ext[Email Extension Plugin] allows executing a script to determine whether an email should be sent.
+For example, the {plugin}/email-ext[Email Extension Plugin] allows executing a script to determine whether an email should be sent.
 
-All such functionality, if available to users without Overall/Administer, must integrate with plugin:script-security[Script Security Plugin].
+All such functionality, if available to users without Overall/Administer, must integrate with {plugin}/script-security[Script Security Plugin].

--- a/docs/dev-docs/modules/security/pages/remoting-callables.adoc
+++ b/docs/dev-docs/modules/security/pages/remoting-callables.adoc
@@ -1,7 +1,7 @@
 = Remoting Callables
 
 Remoting is the library implementing communication between Jenkins processes using Java serialization.
-This applies to controller/agent communications and agents communicating with the Maven process in plugin:maven-plugin[Maven Integration Plugin].
+This applies to controller/agent communications and agents communicating with the Maven process in {plugin}/maven-plugin[Maven Integration Plugin].
 
 `hudson.remoting.Callable` is the basic building block of this communication channel, representing a message and corresponding response.
 Objects implementing this interface get serialized and sent to the other end of the channel.

--- a/docs/dev-docs/modules/security/pages/secrets.adoc
+++ b/docs/dev-docs/modules/security/pages/secrets.adoc
@@ -6,7 +6,7 @@ With simple `String` fields that get serialized to disk as plain text, a number 
 
 * On many systems, large parts of the Jenkins home directory is accessible to other user accounts, allowing to retrieve credentials stored on disk as plain text.
 * Backups of Jenkins home can be compromised, disclosing secrets, even when excluding the +secrets/+ directory.
-* String fields are round-tripped in configuration forms as plain text even if the value is hidden in a password field, so can be accessed via the HTML page source code. This even applies to users who only have the plugin:extended-read-permission[Extended Read] permission.
+* String fields are round-tripped in configuration forms as plain text even if the value is hidden in a password field, so can be accessed via the HTML page source code. This even applies to users who only have the {plugin}/extended-read-permission[Extended Read] permission.
 
 The easiest solution to all of the above is to store the password as a jenkinsdoc:Secret[Secret].
 
@@ -14,7 +14,7 @@ The easiest solution to all of the above is to store the password as a jenkinsdo
 * `Secret` fields are round-tripped in their encrypted form, so that their plain-text form cannot be retrieved by users later.
   If a user only has the Extended Read permission, the secret is simply removed from output.
 
-A more advanced option is to integrate with plugin:credentials[Credentials Plugin]. See https://github.com/jenkinsci/credentials-plugin/tree/master/docs[its documentation] for more information.
+A more advanced option is to integrate with {plugin}/credentials[Credentials Plugin]. See https://github.com/jenkinsci/credentials-plugin/tree/master/docs[its documentation] for more information.
 
 ### Storing Secrets on Disk
 

--- a/docs/dev-docs/modules/security/pages/xss-prevention.adoc
+++ b/docs/dev-docs/modules/security/pages/xss-prevention.adoc
@@ -68,7 +68,7 @@ blurb=<a href="https://jenkins.io/">{0}</a>
 === Rendering Pre-Escaped Content
 
 In rare cases, it might be necessary to render content that has previously been escaped or otherwise processed, without further escaping.
-A common reason to do this is to support formatting using the jenkinsdoc:MarkupFormatter[markup formatter configured for the current Jenkins instance], with might support a plugin:antisamy-markup-formatter[safe subset of HTML], or other markup languages, like plugin:pegdown-formatter[Markdown].
+A common reason to do this is to support formatting using the jenkinsdoc:MarkupFormatter[markup formatter configured for the current Jenkins instance], with might support a {plugin}/antisamy-markup-formatter[safe subset of HTML], or other markup languages, like {plugin}/pegdown-formatter[Markdown].
 In those cases, the security is controlled by the markup formatter.
 
 To do that, use the `<j:out>` Jelly tag:

--- a/docs/dev-docs/modules/testing/pages/index.adoc
+++ b/docs/dev-docs/modules/testing/pages/index.adoc
@@ -184,7 +184,7 @@ project.setScm(new ExtractResourceSCM(getClass().getResource("files-and-folders.
 ===== Within a Pipeline
 Pipeline projects don't have the concept of a single SCM, like Freestyle projects do, but offer a variety of ways to places files into a workspace.
 
-At its most simple, you can use the link:/doc/pipeline/steps/workflow-basic-steps/#writefile-write-file-to-workspace[`writeFile`] step from the plugin:workflow-basic-steps[Pipeline: Basic Steps plugin]. For example:
+At its most simple, you can use the link:/doc/pipeline/steps/workflow-basic-steps/#writefile-write-file-to-workspace[`writeFile`] step from the {plugin}/workflow-basic-steps[Pipeline: Basic Steps plugin]. For example:
 
 [source,java]
 ----
@@ -203,7 +203,7 @@ At its most simple, you can use the link:/doc/pipeline/steps/workflow-basic-step
 ----
 <1> The `node` allocates a workspace on an agent, so that we have somewhere to write files to.
 
-Alternatively, you can use the link:/doc/pipeline/steps/pipeline-utility-steps/#unzip-extract-zip-file[`unzip`] step from the plugin:pipeline-utility-steps[Pipeline Utility Steps plugin] to copy multiple files and folders into the workspace.
+Alternatively, you can use the link:/doc/pipeline/steps/pipeline-utility-steps/#unzip-extract-zip-file[`unzip`] step from the {plugin}/pipeline-utility-steps[Pipeline Utility Steps plugin] to copy multiple files and folders into the workspace.
 
 First, add the plugin to your POM as a test dependency — you can find the `groupId` and `artifactId` values in the link:https://github.com/jenkinsci/pipeline-utility-steps-plugin/blob/master/pom.xml[plugin POM]:
 [source,xml]

--- a/docs/dev-docs/modules/tutorial-improve/pages/move-description-to-index.adoc
+++ b/docs/dev-docs/modules/tutorial-improve/pages/move-description-to-index.adoc
@@ -15,7 +15,7 @@ When such a conversion is needed, the Maven build process will frequently output
 
 [source]
 ----
-[ERROR] Failed to execute goal maven-hpi-plugin:hpi (default-hpi) on
+[ERROR] Failed to execute goal maven-hpi-{plugin}/hpi (default-hpi) on
 project your-plugin: Missing target/classes/index.jelly. Delete any
 <description> from pom.xml and create src/main/resources/index.jelly:
 ----
@@ -30,7 +30,7 @@ Compile the plugin (with a recent parent pom) and confirm that the description t
 [source,bash]
 ----
 mvn -ntp clean verify
-[ERROR] Failed to execute goal maven-hpi-plugin:hpi (default-hpi) on
+[ERROR] Failed to execute goal maven-hpi-{plugin}/hpi (default-hpi) on
 project your-plugin: Missing target/classes/index.jelly. Delete any
 <description> from pom.xml and create src/main/resources/index.jelly:
 ----

--- a/docs/dev-docs/modules/views/pages/exposing-bundled-resources.adoc
+++ b/docs/dev-docs/modules/views/pages/exposing-bundled-resources.adoc
@@ -78,7 +78,7 @@ Example: https://github.com/jenkinsci/jenkins/blob/master/war/src/main/webapp/ro
 This is implemented by `Stapler#service` invoking `#openResourcePathByLocale`.
 This in turn ends up invoking `LocaleDrivenResourceProvider#lookupResource`, an SPI implemented in Jenkins core as `MetaLocaleDrivenResourceProvider` from 2.173.
 This in turn looks up implementations of `PluginLocaleDrivenResourceProvider` in plugins.
-plugin:localization-support[Localization Support Plugin] provides `PluginLocaleDrivenResourceProviderImpl`.
+{plugin}/localization-support[Localization Support Plugin] provides `PluginLocaleDrivenResourceProviderImpl`.
 
 These resources are available to any user without authentication, not requiring _Overall/Read_ permission.
 

--- a/docs/dev-docs/modules/views/pages/read-only.adoc
+++ b/docs/dev-docs/modules/views/pages/read-only.adoc
@@ -18,7 +18,7 @@ There are 3 permissions currently that interact with read-only views:
 * Job/ExtendedRead
 
 They are currently not enabled by default, the easiest way to enable them is to install
-the plugin:extended-read-permission[Extended read permission plugin] v3.2 or above.
+the {plugin}/extended-read-permission[Extended read permission plugin] v3.2 or above.
 
 == Enabling read-only view support
 

--- a/docs/solutions/modules/ROOT/pages/android.adoc
+++ b/docs/solutions/modules/ROOT/pages/android.adoc
@@ -9,11 +9,11 @@ As one of the predominant mobile platforms, Android is attractive to a number
 of developers, but it does bring it's own set of challenges with it. With an
 extremely broad set of devices available on the market, building and testing
 for the matrix of device configurations can be very challenging. With the
-plugin:android-emulator[Android emulator plugin]
+{plugin}/android-emulator[Android emulator plugin]
 however, it is possible to build and test on a myriad of emulated devices.
 
 When combined with the
-plugin:google-play-android-publisher[Google Play Publisher plugin],
+{plugin}/google-play-android-publisher[Google Play Publisher plugin],
 Android developers can build true continuous delivery
 pipeline, sending builds to an alpha channel in Google Play for release or
 further testing.

--- a/docs/solutions/modules/ROOT/pages/bitbucketserver.adoc
+++ b/docs/solutions/modules/ROOT/pages/bitbucketserver.adoc
@@ -2,7 +2,7 @@
 
 link:https://www.atlassian.com/software/bitbucket/enterprise/data-center[Bitbucket Server] is a Git repository management solution designed for professional teams. It's part of the link:http://www.atlassian.com/[Atlassian] product family along with Jira, Confluence, and many more tools designed to help teams unleash their full potential.
 
-To integrate it with Jenkins, you can install the :plugin:atlassian-bitbucket-server-integration[Bitbucket Server integration for Jenkins plugin]. This plugin, which is built and supported by Atlassian, is the easiest way to connect these two tools. It features:
+To integrate it with Jenkins, you can install the :{plugin}/atlassian-bitbucket-server-integration[Bitbucket Server integration for Jenkins plugin]. This plugin, which is built and supported by Atlassian, is the easiest way to connect these two tools. It features:
 
 - Support for Multibranch Pipeline, Jenkins Freestyle, and Pipeline project types
 - Automatic webhook creation in a Bitbucket Server repo when a Jenkins job is saved

--- a/docs/solutions/modules/ROOT/pages/embedded.adoc
+++ b/docs/solutions/modules/ROOT/pages/embedded.adoc
@@ -32,8 +32,8 @@ environments, a few of the following approaches can be considered:
   Variables_ section. Once the variable is modified, the build agent should be
   reconnected.
 . In order to integrate setup the tool environment, consider
-  plugin:custom-tools-plugin[Custom Tools Plugin].
-. plugin:envinject[EnvInject Plugin] allows to setup custom environments at the job level.
+  {plugin}/custom-tools-plugin[Custom Tools Plugin].
+. {plugin}/envinject[EnvInject Plugin] allows to setup custom environments at the job level.
 
 === Working with FPGA boards and hardware peripherals
 
@@ -43,9 +43,9 @@ attempting to access the same shared external peripherals at the same time.
 There are a few plugins which can help manage concurrent peripherals access
 such as the:
 
-. plugin:throttle-concurrents[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
-. plugin:build-timeout[Build Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
-. plugin:naginator[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
+. {plugin}/throttle-concurrents[Throttle Concurrent Builds Plugin] allows preventing hardware and license usage conflicts.
+. {plugin}/build-timeout[Build Timeout Plugin] helps prevent tools (e.g. cable drives) which might hang for whatever reason, blocking a Jenkins build indefinitely.
+. {plugin}/naginator[Naginator Plugin] enables conditional restarting of builds in case of flakey hardware issues.
 
 
 === Working with computing grids
@@ -79,11 +79,11 @@ supported by existing Jenkins plugins.
 For tools which generate some form of XML-based reports, formatting of those
 reports can be implemented with an XSLT converter. Consider the following plugins for incorporating generated reports into Jenkins:
 
-* Unit testing results: plugin:xunit[xUnit Plugin], which
+* Unit testing results: {plugin}/xunit[xUnit Plugin], which
   provides a "Custom report" handler to convert any XML to JUnit formatted reports for Jenkins
-* Timing analysis reports: plugin:performance[Performance plugin]
+* Timing analysis reports: {plugin}/performance[Performance plugin]
   (support JMeter-alike reports)
-* Code coverage: plugin:cobertura[Cobertura Plugin] or plugin:emma[Emma Plugin]
+* Code coverage: {plugin}/cobertura[Cobertura Plugin] or {plugin}/emma[Emma Plugin]
 
 
 == Presentations

--- a/docs/solutions/modules/ROOT/pages/github.adoc
+++ b/docs/solutions/modules/ROOT/pages/github.adoc
@@ -14,11 +14,11 @@ The primary avenues for integrating your Jenkins instance with GitHub are:
 
 == Build integration
 
-With the help of the plugin:git[Git plugin]
+With the help of the {plugin}/git[Git plugin]
 Jenkins can easily pull source code from any Git repository that the Jenkins
 build node can access.
 
-The plugin:github[GitHub plugin] extends
+The {plugin}/github[GitHub plugin] extends
 upon that integration further by providing improved bi-directional
 integration with GitHub. Allowing you to set up a link:https://developer.github.com/webhooks/#service-hooks[Service
 Hook] which will hit
@@ -34,11 +34,11 @@ link:https://stackoverflow.com/questions/14274293/show-current-state-of-jenkins-
 
 == Authenticating with GitHub
 
-Using the plugin:github-oauth[GitHub Authentication plugin]
+Using the {plugin}/github-oauth[GitHub Authentication plugin]
 it is possible to use GitHub's own authentication scheme
 for implementing authentication in your Jenkins instance.
 
-The **plugin:github-oauth#GithubOAuthPlugin-Setup[setup guide]**
+The **{plugin}/github-oauth#plugin-content-setup[setup guide]**
 will help walk you through configuring the GitHub OAuth side, and your
 Jenkins instance, to provide easy authentication/authorization for users.
 

--- a/docs/solutions/modules/ROOT/pages/java.adoc
+++ b/docs/solutions/modules/ROOT/pages/java.adoc
@@ -24,7 +24,7 @@ image::jenkins-maven-step.png['Jenkins Maven step', role=center]
 == Gradle
 
 As the associated plugin is not installed by default, first install the
-plugin:gradle[Gradle plugin].
+{plugin}/gradle[Gradle plugin].
 Once done, you should be able to add a Gradle step.
 
 

--- a/docs/solutions/modules/ROOT/pages/php.adoc
+++ b/docs/solutions/modules/ROOT/pages/php.adoc
@@ -42,9 +42,9 @@ PHP code is in the `src` subdirectory.
 
 The following configuration will set up 3 reports for PHPUnit tests:
 
-* Pass/fail monitoring via the plugin:xunit[xUnit plugin]
-* Coverage stats via the plugin:code-coverage-api[Code Coverage API plugin] (using the cobertura adaptor)
-* HTML coverage report via the plugin:htmlpublisher[HTML Publisher plugin]
+* Pass/fail monitoring via the {plugin}/xunit[xUnit plugin]
+* Coverage stats via the {plugin}/code-coverage-api[Code Coverage API plugin] (using the cobertura adaptor)
+* HTML coverage report via the {plugin}/htmlpublisher[HTML Publisher plugin]
 
 In the PHPUnit config file (`phpunit.xml` or `phpunit.xml.dist`):
 
@@ -102,7 +102,7 @@ In this example, PHPCS is shown running with 2 different configurations (mainly
 to show this can be done).
 
 Reports are processed using the CheckStyle format report and the
-plugin:warnings-ng[Warnings Next Generation plugin]
+{plugin}/warnings-ng[Warnings Next Generation plugin]
 
 This is done because PHPCompatibility checks are run across the `vendor/`
 directory to aid in monitoring potential problems for version updates.

--- a/docs/solutions/modules/ROOT/pages/pipeline.adoc
+++ b/docs/solutions/modules/ROOT/pages/pipeline.adoc
@@ -16,7 +16,7 @@ best practices to the job configurations themselves.
 
 == Pipeline
 
-With the introduction of the plugin:workflow-aggregator[Pipeline plugin],
+With the introduction of the {plugin}/workflow-aggregator[Pipeline plugin],
 users now can implement a project's entire build/test/deploy pipeline
 in a `Jenkinsfile` and store that alongside their code, treating their
 pipeline as another piece of code checked into source control.
@@ -33,14 +33,14 @@ features like:
   "link:/doc/book/pipeline/shared-libraries/[Shared Libraries]" feature.
 
 In an adjacent space is the
-plugin:job-dsl[Job DSL plugin]
+{plugin}/job-dsl[Job DSL plugin]
 which is worth mentioning as well.
 
 
 == Getting Started
 
 * link:/doc/pipeline[Getting Started with Pipeline]
-* The plugin:workflow-aggregator[Pipeline plugin]
+* The {plugin}/workflow-aggregator[Pipeline plugin]
   has a fairly comprehensive
   link:https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md[tutorial]
   checked into its source tree too.
@@ -63,7 +63,7 @@ Demonstrations of Pipeline functionality you can run locally.
 
 == Additional resources
 
-* plugin:workflow-aggregator[Pipeline Plugin page]
+* {plugin}/workflow-aggregator[Pipeline Plugin page]
 * link:https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md[Plugins compatible with Pipeline]
 * link:https://stackoverflow.com/questions/tagged/jenkins-pipeline[Stack Overflow "jenkins-pipeline" tag]
 * link:https://github.com/jenkinsci/pipeline-examples[Examples/snippets repository]
@@ -79,7 +79,7 @@ A presentation by link:https://github.com/kohsuke[Kohsuke Kawaguchi], link:https
 </center>
 ++++
 
-The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the plugin:workflow-aggregator[Pipeline Plugin]
+The presentations below were given by link:https://github.com/jglick[Jesse Glick], author of the {plugin}/workflow-aggregator[Pipeline Plugin]
 
 ++++
 <center>

--- a/docs/solutions/modules/ROOT/pages/python.adoc
+++ b/docs/solutions/modules/ROOT/pages/python.adoc
@@ -14,7 +14,7 @@ for testing/reporting such as:
 
 * link:https://github.com/nose-devs/nose2[nose2] and link:https://docs.pytest.org/en/latest[pytest]
   for executing unit tests and generating JUnit-compatible XML test reports _and_
-  plugin:cobertura[Cobertura]-compatible
+  {plugin}/cobertura[Cobertura]-compatible
   code coverage reports.
 
 

--- a/docs/solutions/modules/ROOT/pages/ruby.adoc
+++ b/docs/solutions/modules/ROOT/pages/ruby.adoc
@@ -24,13 +24,13 @@ image::junit-rspec-postbuild-action.png[Configured JUnit post-build action, role
 
 By integrating the test reports into Jenkins, you can generate trends and
 reports. There are other plugins, such as the
-plugin:email-ext[Email Ext plugin]
+{plugin}/email-ext[Email Ext plugin]
 which can also make use of these machine-readable test reports to send
 email notifications with only the failing test cases listed.
 
 image::junit-rspec-trend.png[Trending RSpec test reports, role=center]
 
-Using plugins such as the plugin:cucumber-testresult-plugin[Cucumber Test Result plugin]
+Using plugins such as the {plugin}/cucumber-testresult-plugin[Cucumber Test Result plugin]
 improve the integration and discoverability of successful/unsuccessful
 Cucumber scenarios.
 

--- a/docs/tutorials/modules/ROOT/pages/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
+++ b/docs/tutorials/modules/ROOT/pages/using-jenkinsfile-runner-github-action-to-build-jenkins-pipeline.adoc
@@ -241,7 +241,7 @@ with:
   jcasc: jcasc.yml
 ----
 
-For additional information, refer to the link:https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples] provided by the plugin:configuration-as-code[Configuration as Code] plugin, and learn how to configure the Jenkins instance without using the UI page. 
+For additional information, refer to the link:https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos[examples] provided by the {plugin}/configuration-as-code[Configuration as Code] plugin, and learn how to configure the Jenkins instance without using the UI page. 
 Some plugins do not have concrete examples, but you can debug and find their JCasC in the UI page. 
 You can check the configuration in *Manage Jenkins* -> *Configuration as Code* -> *View Configuration*. 
 Then, you can copy the parts you need to the JCasC file.

--- a/docs/user-docs/modules/administration/pages/requirements/java.adoc
+++ b/docs/user-docs/modules/administration/pages/requirements/java.adoc
@@ -47,7 +47,7 @@ This includes:
 * Execution of Maven/Ant/… build steps using a JDK managed by a JDK link:https://plugins.jenkins.io/jdk-tool/[tool installer]
 
 A few plugins have more strict requirements, generally requiring that a build is executing in the same version of Java as is used to run the Jenkins controller and agents.
-A notable example of that is plugin:maven-plugin[Maven Integration Plugin], which requires that the version of the JDK used for the Maven build must be at least the same version as is used for the Jenkins controller.
+A notable example of that is {plugin}/maven-plugin[Maven Integration Plugin], which requires that the version of the JDK used for the Maven build must be at least the same version as is used for the Jenkins controller.
 These cases are generally documented in the plugin documentation.
 // This used to list Swarm Plugin Clients, but since they are agent processes that's kind of redundant.
 // TODO This used to list docker-workflow, but it's unclear why.
@@ -57,7 +57,7 @@ These cases are generally documented in the plugin documentation.
 Modern versions of Jenkins controllers and Jenkins agents verify Java requirements
 and notify users when they are launched with an unsupported version.
 
-The plugin:versioncolumn[Versions Node Monitors plugin] provides detailed Java version monitoring.
+The {plugin}/versioncolumn[Versions Node Monitors plugin] provides detailed Java version monitoring.
 
 ## Java Development Kits Used
 

--- a/docs/user-docs/modules/administration/pages/requirements/upgrade-java-guidelines.adoc
+++ b/docs/user-docs/modules/administration/pages/requirements/upgrade-java-guidelines.adoc
@@ -39,7 +39,7 @@ NOTE: If you discover a previously unreported issue, please let us know: read li
 
 // Commented because pipeline support plugin 3.0 is over 3 years old and has 8+ later releases
 //
-// One of the most important plugin upgrades is the plugin:workflow-support[Pipeline: Support plugin]: make sure that the version of the plugin is at least `3.0`.
+// One of the most important plugin upgrades is the {plugin}/workflow-support[Pipeline: Support plugin]: make sure that the version of the plugin is at least `3.0`.
 //
 // NOTE: Stop all Pipeline jobs before upgrading this plugin because this upgrade changes the serialization of Pipeline builds. As a general rule, even though Pipeline jobs are supposed to survive a Jenkins restart, it's always a better option to make sure that no Pipeline builds are in progress before any scheduled Jenkins maintenance.
 
@@ -48,7 +48,7 @@ NOTE: If you discover a previously unreported issue, please let us know: read li
 Some plugins use JAXB libraries provided by the JDK.
 However, the `java.xml.bind` and `javax.activation` modules are no longer included in OpenJDK 11, and plugins might fail if no replacement is offered.
 
-To fix this problem, we've bundled those libraries into a new detached plugin: plugin:jaxb[JAXB plugin].
+To fix this problem, we've bundled those libraries into a new detached {plugin}/ {plugin}/jaxb[JAXB plugin].
 When any Jenkins core more recent than `2.163` is running on Java 11, this plugin is automatically installed.
 However, if you manage your plugins outside Jenkins, for example, if you use `plugins.txt` in your Docker images, you might need to install the plugin explicitly.
 
@@ -57,7 +57,7 @@ However, if you manage your plugins outside Jenkins, for example, if you use `pl
 All agents must be running on the same JVM version as the controller due to how controllers and agents communicate.
 If you're upgrading your Jenkins controller to run on Java 11, you also need to upgrade the JVM on your agents.
 
-You can validate the version of each agent with the plugin:versioncolumn[Versions Node Monitors] plugin.
+You can validate the version of each agent with the {plugin}/versioncolumn[Versions Node Monitors] plugin.
 This plugin provides information about the JVM version of each agent on the node management screen of your Jenkins instance.
 You can also configure this plugin to automatically disconnect any agent with an incorrect JVM version.
 
@@ -68,7 +68,7 @@ When a Jenkins controller runs on Java 11, the Java Web Start button will no lon
 You can't launch agents for a Java 11 Jenkins server from a `*.jnlp` file downloaded to a web browser.
 
 There are no plans to replace this functionality.
-Connect agents to Jenkins on Java 11 with plugins like plugin:ssh-slaves[SSH Build Agents Plugin], with operating system command line calls to `java -jar agent.jar`, or using containers.
+Connect agents to Jenkins on Java 11 with plugins like {plugin}/ssh-slaves[SSH Build Agents Plugin], with operating system command line calls to `java -jar agent.jar`, or using containers.
 
 == JDK Tool Automatic installer
 

--- a/docs/user-docs/modules/administration/pages/requirements/windows.adoc
+++ b/docs/user-docs/modules/administration/pages/requirements/windows.adoc
@@ -7,7 +7,7 @@ This page documents the Windows support policy for the Jenkins server and agents
 
 == Scope
 
-Jenkins plugins, e.g., plugin:windows-slaves[WMI Windows Agents],
+Jenkins plugins, e.g., {plugin}/windows-slaves[WMI Windows Agents],
 may set additional requirements to Windows versions on controllers and/or agents.
 This page does not document such requirements. Please refer to plugin documentation.
 


### PR DESCRIPTION
Used asciidoc custom attributes across the whole site
replaced `plugin:plugin-name` with `{plugin}/plugin-name` 