### PR TITLE
Install `jstz` using npm

### DIFF
--- a/docs/events/modules/ROOT/pages/index.adoc
+++ b/docs/events/modules/ROOT/pages/index.adoc
@@ -107,10 +107,9 @@ We have a calendar which lists events related to Jenkins, including regular SIG 
 
 ++++
 <!-- Using JSTZ time zone detection library -->
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.7/jstz.min.js"></script>
+<!--<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.7/jstz.min.js"></script>-->
 
 <script type="text/javascript">
-  const jstz = require('jstz');
   const deviceTimeZone = jstz.determine().name();
   const calendarSrc = 'https://calendar.google.com/calendar/b/1/embed'
       + '?showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;mode=WEEK'

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@types/jquery": "^3.5.16",
-        "datatables.net-dt": "^1.13.4"
+        "datatables.net-dt": "^1.13.4",
+        "jstz": "^2.1.1"
       },
       "devDependencies": {
         "yaml-lint": "^1.2.4"
@@ -274,6 +275,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jstz": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jstz/-/jstz-2.1.1.tgz",
+      "integrity": "sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/leprechaun": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@types/jquery": "^3.5.16",
-    "datatables.net-dt": "^1.13.4"
+    "datatables.net-dt": "^1.13.4",
+    "jstz": "^2.1.1"
   }
 }


### PR DESCRIPTION
Install `jstz` using npm instead of using original library delivered via CDNJS. 