### PR TITLE
Remove circular page-alias from `projects/gsoc/index.adoc`

### DIFF
--- a/docs/projects/modules/gsoc/pages/index.adoc
+++ b/docs/projects/modules/gsoc/pages/index.adoc
@@ -1,4 +1,3 @@
-:page-aliases: projects:gsoc:index.adoc
 = Jenkins in Google Summer of Code
 
 // image:/images/gsoc/jenkins-gsoc-logo_small.png[Jenkins GSoC, role=center, float=left]


### PR DESCRIPTION
This was failing the GitHub Actions due to circular page-alias in `projects/gsoc/index.adoc`