### PR TITLE
Redirect /node to /blog

### DIFF
--- a/site/gatsby-node.js
+++ b/site/gatsby-node.js
@@ -21,7 +21,7 @@ exports.createPages = ({ graphql, actions }) => {
 
   createRedirect({
     fromPath: `/node`,
-    toPath: `/node/`,
+    toPath: `/blog/`,
     isPermanent: true,
     redirectInBrowser: true,
     force: true,


### PR DESCRIPTION
https://github.com/Vandit1604/jenkins-docs/blob/main/site/gatsby-node.js#L22-L28

```js
  createRedirect({
    fromPath: `/node`,
    toPath: `/node/`,
    isPermanent: true,
    redirectInBrowser: true,
    force: true,
  });
```

Here, We are redirecting `/node` to `/node/`
then it redirects to `/blog/`

I propose directly redirecting to `/blog/` whether we hit `/node` or `/node/`